### PR TITLE
Replace deprecated statement elseif with else if

### DIFF
--- a/dist/_spread.scss
+++ b/dist/_spread.scss
@@ -146,21 +146,21 @@
     $left: $list;
   }
   // top/bottom match, left/right match
-  @elseif ($list-size == 2) {
+  @else if ($list-size == 2) {
     $top: nth($list, 1);
     $bottom: nth($list, 1);
     $right: nth($list, 2);
     $left: nth($list, 2);
   }
   // top/bottom differ, left/right match
-  @elseif ($list-size == 3) {
+  @else if ($list-size == 3) {
     $top: nth($list, 1);
     $right: nth($list, 2);
     $left: nth($list, 2);
     $bottom: nth($list, 3);
   }
   // top/bottom/left/right differ
-  @elseif ($list-size == 4) {
+  @else if ($list-size == 4) {
     @return $list;
 
   } @else {

--- a/src/_split-list.scss
+++ b/src/_split-list.scss
@@ -14,21 +14,21 @@
     $left: $list;
   }
   // top/bottom match, left/right match
-  @elseif ($list-size == 2) {
+  @else if ($list-size == 2) {
     $top: nth($list, 1);
     $bottom: nth($list, 1);
     $right: nth($list, 2);
     $left: nth($list, 2);
   }
   // top/bottom differ, left/right match
-  @elseif ($list-size == 3) {
+  @else if ($list-size == 3) {
     $top: nth($list, 1);
     $right: nth($list, 2);
     $left: nth($list, 2);
     $bottom: nth($list, 3);
   }
   // top/bottom/left/right differ
-  @elseif ($list-size == 4) {
+  @else if ($list-size == 4) {
     @return $list;
 
   } @else {


### PR DESCRIPTION
If you compile this with the reference sass compiler (dart-sass) you end up with the following deprecation

```
DEPRECATION WARNING on line 149, column 3 of node_modules/include-media-spread/dist/_spread.scss: 
@elseif is deprecated and will not be supported in future Sass versions.
Use "@else if" instead.
    ╷
149 │   @elseif ($list-size == 2) {
    │   ^^^^^^^
    ╵
```